### PR TITLE
Demo of adding a command to the command palette

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -27,8 +27,13 @@ export default {
                 return el;
             }
         });
-
+        
+        //                scope for command     name of command      command function
+        //                       |                     |                    |
+        atom.commands.add('atom-text-editor', 'jupyter:new-command', this.myNewCommand);
     },
+    
+    myNewCommand: () => {},
 
     deactivate: function() {
         this.openerDisposable.dispose()


### PR DESCRIPTION
This command will be visible in the Atom command palette.

Users can access it by hitting ⌘-⇧-P (or platform equivalent), then starting to type the command name. It will be found using fast fuzzy search and will show up as "Jupyter: New Command". 

The user can also bind it to a keyboard shortcut of their choosing using the excellent Atom keybindings menu, which looks like this:

<img width="1285" alt="screenshot 2015-08-05 23 04 36" src="https://cloud.githubusercontent.com/assets/597829/9102921/648fc7ba-3bc6-11e5-8f3b-0cd98a915c63.png">