### PR TITLE
add .toLowerScript() fix from the hydrogen package

### DIFF
--- a/lib/text-editor.js
+++ b/lib/text-editor.js
@@ -23,7 +23,7 @@ export default class Editor extends React.Component {
 
     static getGrammarForLanguage(language) {
         let matchingGrammars = atom.grammars.grammars.filter(grammar => {
-            return grammar.name.toLowerCase() == language.toLowerCase();
+            return grammar !== atom.grammars.nullGrammar && (grammar.name != null) && (grammar.name.toLowerCase != null) && grammar.name.toLowerCase() === language;
         });
         return matchingGrammars[0];
     }


### PR DESCRIPTION
see issue https://github.com/willwhitney/hydrogen/issues/82, commit https://github.com/willwhitney/hydrogen/commit/5022f79124d853967c353d3b26cb82169ad8e765 

used the coffeescript.org converter, plugged in the return statement. fire up atom and the notebook now loads as expected.

should address https://github.com/jupyter/atom-notebook/issues/6