### PR TITLE
Conform to Jupyter Notebook file format

### DIFF
--- a/lib/display-area.js
+++ b/lib/display-area.js
@@ -25,16 +25,12 @@ export default class DisplayArea extends React.Component {
     };
   }
 
+  componentWillMount() {
+    this.transformMimeBundle(this.props);
+  }
+
   componentWillReceiveProps(nextProps) {
-    let promises = nextProps.data.get('outputs').toJS().map(output => {
-      let mimeBundle = this.makeMimeBundle(output);
-      if (mimeBundle) {
-        return this.transformer.transformRichest(mimeBundle, document).then(mime => mime.el.outerHTML);
-      } else return;
-		});
-    Promise.all(promises).then(outputs => {
-      this.setState({outputs: outputs.join('')});
-    });
+    this.transformMimeBundle(nextProps);
   }
 
   render() {
@@ -72,6 +68,18 @@ export default class DisplayArea extends React.Component {
   			};
   	}
   	return bundle;
+  }
+
+  transformMimeBundle(props) {
+    let promises = props.data.get('outputs').toJS().map(output => {
+      let mimeBundle = this.makeMimeBundle(output);
+      if (mimeBundle) {
+        return this.transformer.transformRichest(mimeBundle, document).then(mime => mime.el.outerHTML);
+      } else return;
+		});
+    Promise.all(promises).then(outputs => {
+      this.setState({outputs: outputs.join('')});
+    });
   }
 
 }

--- a/lib/display-area.js
+++ b/lib/display-area.js
@@ -37,10 +37,24 @@ export default class DisplayArea extends React.Component {
     return (
       <div className="cell-display-area native-key-bindings"
         tabIndex="-1"
-        dangerouslySetInnerHTML={{__html: this.state.outputs}}
+        dangerouslySetInnerHTML={{__html: this.state.outputs.join('')}}
       >
       </div>
     );
+  }
+
+  transformMimeBundle(props) {
+    if (props.data.get('outputs')) {
+      let promises = props.data.get('outputs').toJS().map(output => {
+        let mimeBundle = this.makeMimeBundle(output);
+        if (mimeBundle) {
+          return this.transformer.transformRichest(mimeBundle, document).then(mime => mime.el.outerHTML);
+        } else return;
+  		});
+      Promise.all(promises).then(outputs => {
+        this.setState({outputs});
+      });
+    }
   }
 
   makeMimeBundle(msg) {
@@ -51,10 +65,8 @@ export default class DisplayArea extends React.Component {
   			bundle = msg.data;
   			break;
   		case 'stream':
-  			bundle = {'text/plain': msg.text};
-  			// bundle = {
-  			//   'jupyter/stream': msg
-  			// };
+  			bundle = {'text/plain': msg.text.join('')};
+  			// bundle = {'jupyter/stream': msg};
   			break;
   		case 'error':
   			bundle = {
@@ -68,18 +80,6 @@ export default class DisplayArea extends React.Component {
   			};
   	}
   	return bundle;
-  }
-
-  transformMimeBundle(props) {
-    let promises = props.data.get('outputs').toJS().map(output => {
-      let mimeBundle = this.makeMimeBundle(output);
-      if (mimeBundle) {
-        return this.transformer.transformRichest(mimeBundle, document).then(mime => mime.el.outerHTML);
-      } else return;
-		});
-    Promise.all(promises).then(outputs => {
-      this.setState({outputs: outputs.join('')});
-    });
   }
 
 }

--- a/lib/display-area.js
+++ b/lib/display-area.js
@@ -20,39 +20,31 @@ export default class DisplayArea extends React.Component {
 		this.transformer.transformers.push(new MarkdownTransformer());
 		this.transformer.transformers.push(new LaTeXTransformer());
 		this.transformer.transformers.push(new PDFTransformer());
+    this.state = {
+      outputs: []
+    };
   }
 
-  componentDidMount() {
-    this.setupDOM();
-  }
-
-  componentDidUpdate() {
-    this.el.innerHTML = '';
-    let outputs = this.props.data.get('outputs').forEach(output => {
+  componentWillReceiveProps(nextProps) {
+    let promises = nextProps.data.get('outputs').toJS().map(output => {
       let mimeBundle = this.makeMimeBundle(output);
       if (mimeBundle) {
-        this.transformer.transformRichest(mimeBundle, document).then(res => {
-          this.el.innerHTML += res.el.outerHTML;
-        });
-      }
+        return this.transformer.transformRichest(mimeBundle, document).then(mime => mime.el.outerHTML);
+      } else return;
 		});
+    Promise.all(promises).then(outputs => {
+      this.setState({outputs: outputs.join('')});
+    });
   }
 
   render() {
     return (
-      <div className="cell-display-area native-key-bindings" tabIndex="-1">
+      <div className="cell-display-area native-key-bindings"
+        tabIndex="-1"
+        dangerouslySetInnerHTML={{__html: this.state.outputs}}
+      >
       </div>
     );
-  }
-
-  setupDOM() {
-    let container = React.findDOMNode(this);
-    let outputNode = document.createElement('div');
-    outputNode.style.backgroundColor = 'white';
-    this.shadow = container.createShadowRoot();
-    this.shadow.appendChild(outputNode);
-    this.document = this.shadow.ownerDocument;
-    this.el = outputNode;
   }
 
   makeMimeBundle(msg) {

--- a/lib/display-area.js
+++ b/lib/display-area.js
@@ -3,32 +3,39 @@
 import React from 'react';
 import {Transformime} from 'transformime';
 import {
-	StreamTransformer,
-	TracebackTransformer,
-	MarkdownTransformer,
-}
-from 'transformime-jupyter-transformers';
+  StreamTransformer,
+  TracebackTransformer,
+  MarkdownTransformer,
+  LaTeXTransformer,
+  PDFTransformer
+} from 'transformime-jupyter-transformers';
 
 export default class DisplayArea extends React.Component {
 
   constructor(props) {
-      super(props);
-    this.transformer = new Transformime();
-    this.transformer.transformers.push(new StreamTransformer());
-    this.transformer.transformers.push(new TracebackTransformer());
-      this.transformer.transformers.push(new MarkdownTransformer());
+    super(props);
+		this.transformer = new Transformime();
+		this.transformer.transformers.push(new StreamTransformer());
+		this.transformer.transformers.push(new TracebackTransformer());
+		this.transformer.transformers.push(new MarkdownTransformer());
+		this.transformer.transformers.push(new LaTeXTransformer());
+		this.transformer.transformers.push(new PDFTransformer());
   }
 
   componentDidMount() {
     this.setupDOM();
   }
 
-  // transformime-generated HTML is in outputs
-  // after every render, fill our element with that HTML
   componentDidUpdate() {
-    let outputs = this.props.data.get('outputs');
-    let outputHTML = outputs.join('');
-    this.el.innerHTML = outputHTML;
+    this.el.innerHTML = '';
+    let outputs = this.props.data.get('outputs').forEach(output => {
+      let mimeBundle = this.makeMimeBundle(output);
+      if (mimeBundle) {
+        this.transformer.transformRichest(mimeBundle, document).then(res => {
+          this.el.innerHTML += res.el.outerHTML;
+        });
+      }
+		});
   }
 
   render() {
@@ -46,6 +53,33 @@ export default class DisplayArea extends React.Component {
     this.shadow.appendChild(outputNode);
     this.document = this.shadow.ownerDocument;
     this.el = outputNode;
+  }
+
+  makeMimeBundle(msg) {
+  	let bundle = {};
+  	switch (msg.output_type) {
+  		case 'execute_result':
+  		case 'display_data':
+  			bundle = msg.data;
+  			break;
+  		case 'stream':
+  			bundle = {'text/plain': msg.text};
+  			// bundle = {
+  			//   'jupyter/stream': msg
+  			// };
+  			break;
+  		case 'error':
+  			bundle = {
+  				'jupyter/traceback': msg
+  			};
+  			break;
+  		default:
+  			console.warn('Unrecognized output type: ' + msg.output_type);
+  			bundle = {
+  				'text/plain': 'Unrecognized output type' + JSON.stringify(msg)
+  			};
+  	}
+  	return bundle;
   }
 
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -48,7 +48,7 @@ export default {
     // console.log('Run cell');
     Dispatcher.dispatch({
       actionType: Dispatcher.actions.run_active_cell
-      // cellID: this.props.data.get('id')
+      // cellID: this.props.data.getIn(['metadata', 'id'])
     });
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@
 
 import path from 'path';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import {CompositeDisposable} from 'atom';
 import Dispatcher from './dispatcher';
 import NotebookEditor from './notebook-editor';
@@ -19,7 +20,7 @@ export default {
       createView: model => {
         let el = document.createElement('div');
         el.classList.add('notebook-wrapper');
-        let viewComponent = React.render(
+        let viewComponent = ReactDOM.render(
           <NotebookEditorView store={model} />,
           el);
         return el;

--- a/lib/notebook-cell.js
+++ b/lib/notebook-cell.js
@@ -19,7 +19,7 @@ export default class NotebookCell extends React.Component {
   render() {
     // console.log('Cell rendering.');
     let focusClass = '';
-    if (this.props.data.get('focus')) focusClass = ' focused';
+    if (this.props.data.getIn(['metadata', 'focus'])) focusClass = ' focused';
     return (
       <div className={'notebook-cell' + focusClass} onFocus={this.triggerFocused.bind(this, true)}>
         <div className="execution-count-label">
@@ -41,7 +41,7 @@ export default class NotebookCell extends React.Component {
   triggerFocused(isFocused) {
     Dispatcher.dispatch({
       actionType: Dispatcher.actions.cell_focus,
-      cellID: this.props.data.get('id'),
+      cellID: this.props.data.getIn(['metadata', 'id']),
       isFocused: isFocused
     });
   }
@@ -49,7 +49,7 @@ export default class NotebookCell extends React.Component {
   runCell = () => {
     Dispatcher.dispatch({
       actionType: Dispatcher.actions.run_cell,
-      cellID: this.props.data.get('id')
+      cellID: this.props.data.getIn(['metadata', 'id'])
     });
   }
 

--- a/lib/notebook-editor-view.js
+++ b/lib/notebook-editor-view.js
@@ -37,7 +37,7 @@ export default class NotebookEditorView extends React.Component {
     || this.state.data.get('cells') === undefined) {
       return <h1>Not Initialized</h1>;
     } else {
-      let language = this.state.data.getIn(['metadata', 'kernelspec', 'language']);
+      let language = this.state.data.getIn(['metadata', 'language_info', 'name']);
       // console.log('Language:', language);
       let notebookCells = this.state.data.get('cells').map((cell) => {
         cell = cell.set('language', language);

--- a/lib/notebook-editor-view.js
+++ b/lib/notebook-editor-view.js
@@ -44,7 +44,7 @@ export default class NotebookEditorView extends React.Component {
         return (
           <NotebookCell
             data={cell}
-            key={cell.get('id')}
+            key={cell.getIn(['metadata', 'id'])}
             language={language}
           />
         );
@@ -71,21 +71,21 @@ export default class NotebookEditorView extends React.Component {
   addCell() {
     Dispatcher.dispatch({
       actionType: Dispatcher.actions.add_cell
-      // cellID: this.props.data.get('id')
+      // cellID: this.props.data.getIn(['metadata', 'id'])
     });
   }
 
   runActiveCell() {
     Dispatcher.dispatch({
       actionType: Dispatcher.actions.run_active_cell
-      // cellID: this.props.data.get('id')
+      // cellID: this.props.data.getIn(['metadata', 'id'])
     });
   }
 
   interruptKernel() {
     Dispatcher.dispatch({
       actionType: Dispatcher.actions.interrupt_kernel
-      // cellID: this.props.data.get('id')
+      // cellID: this.props.data.getIn(['metadata', 'id'])
     });
   }
 

--- a/lib/notebook-editor-view.js
+++ b/lib/notebook-editor-view.js
@@ -33,39 +33,34 @@ export default class NotebookEditorView extends React.Component {
 
   render() {
     // console.log('notebookeditorview render called');
-    if (this.state.data.get('cells') === null
-    || this.state.data.get('cells') === undefined) {
-      return <h1>Not Initialized</h1>;
-    } else {
-      let language = this.state.data.getIn(['metadata', 'language_info', 'name']);
-      // console.log('Language:', language);
-      let notebookCells = this.state.data.get('cells').map((cell) => {
-        cell = cell.set('language', language);
-        return (
-          <NotebookCell
-            data={cell}
-            key={cell.getIn(['metadata', 'id'])}
-            language={language}
-          />
-        );
-      });
+    let language = this.state.data.getIn(['metadata', 'language_info', 'name']);
+    // console.log('Language:', language);
+    let notebookCells = this.state.data.get('cells').map((cell) => {
+      cell = cell.set('language', language);
       return (
-        <div className="notebook-editor">
-          <header className="notebook-toolbar">
-            <button className="btn icon inline-block-tight icon-plus add-cell" onClick={this.addCell}></button>
-            <div className='inline-block btn-group'>
-              <button className='btn icon icon-playback-play' onClick={this.runActiveCell}></button>
-              <button className='btn icon icon-primitive-square' onClick={this.interruptKernel}></button>
-            </div>
-          </header>
-          <div className="notebook-cells-container">
-            <div className="redundant-cells-container">
-              {notebookCells}
-            </div>
+        <NotebookCell
+          data={cell}
+          key={cell.getIn(['metadata', 'id'])}
+          language={language}
+        />
+      );
+    });
+    return (
+      <div className="notebook-editor">
+        <header className="notebook-toolbar">
+          <button className="btn icon inline-block-tight icon-plus add-cell" onClick={this.addCell}></button>
+          <div className='inline-block btn-group'>
+            <button className='btn icon icon-playback-play' onClick={this.runActiveCell}></button>
+            <button className='btn icon icon-primitive-square' onClick={this.interruptKernel}></button>
+          </div>
+        </header>
+        <div className="notebook-cells-container">
+          <div className="redundant-cells-container">
+            {notebookCells}
           </div>
         </div>
-      );
-    }
+      </div>
+    );
   }
 
   addCell() {

--- a/lib/notebook-editor.js
+++ b/lib/notebook-editor.js
@@ -33,38 +33,7 @@ export default class NotebookEditor {
       this.loadNotebookFile(uri);
       this.emitter = new Emitter();
       this.subscriptions = new CompositeDisposable();
-      let language = this.state.getIn(['metadata', 'kernelspec', 'language']);
-      execSync('lsof -t -i tcp:8888 | xargs kill');
-      this.kernelGateway = spawn('jupyter', ['kernelgateway'], {
-        cwd: atom.project.getPaths()[0]
-      });
-      this.kernelGateway.stdout.on('data', (data) => {
-        console.log('kernelGateway.stdout  ' + data);
-      });
-      this.kernelGateway.stderr.on('data', (data) => {
-        console.log('kernelGateway.stderr ' + data);
-        if (data.toString().includes('The Jupyter Kernel Gateway is running at')) {
-          getKernelSpecs('http://localhost:8888').then((kernelSpecs) => {
-            let spec = Object.keys(kernelSpecs.kernelspecs).find(kernel => kernelSpecs.kernelspecs[kernel].spec.language === language);
-            console.log('Kernel: ', spec);
-            if (spec) {
-              startNewKernel({
-                baseUrl: 'http://localhost:8888',
-                wsUrl: 'ws://localhost:8888',
-                name: spec
-              }).then((kernel) => {
-                this.session = kernel;
-              });
-            }
-          });
-        }
-      });
-      this.kernelGateway.on('close',  (code) => {
-        console.log('kernelGateway.close ' + code);
-      });
-      this.kernelGateway.on('exit', (code) => {
-        console.log('kernelGateway.exit ' + code);
-      });
+      this.launchKernelGateway();
       Dispatcher.register(this.onAction);
       //TODO: remove these development handles
       global.editor = this;
@@ -258,6 +227,45 @@ export default class NotebookEditor {
       return JSON.parse(fileString);
     }
 
+    launchKernelGateway() {
+      let language = this.state.getIn(['metadata', 'kernelspec', 'language']);
+      let port = 8888;
+      try {
+        do {
+          execSync(`lsof -i:${port}`);
+          port++;
+        } while (port < 9000);
+      } catch(error) {
+        this.kernelGateway = spawn('jupyter', ['kernelgateway', '--KernelGatewayApp.ip=localhost', `--KernelGatewayApp.port=${port}`], {
+          cwd: atom.project.getPaths()[0]
+        });
+        this.kernelGateway.stdout.on('data', (data) => {
+          console.log('kernelGateway.stdout  ' + data);
+        });
+        this.kernelGateway.stderr.on('data', (data) => {
+          console.log('kernelGateway.stderr ' + data);
+          if (data.toString().includes('The Jupyter Kernel Gateway is running at')) {
+            getKernelSpecs(`http://localhost:${port}`).then((kernelSpecs) => {
+              let spec = Object.keys(kernelSpecs.kernelspecs).find(kernel => kernelSpecs.kernelspecs[kernel].spec.language === language);
+              console.log('Kernel: ', spec);
+              if (spec) {
+                startNewKernel({
+                  baseUrl: `http://localhost:${port}`,
+                  wsUrl: `ws://localhost:${port}`,
+                  name: spec
+                }).then((kernel) => {
+                  this.session = kernel;
+                });
+              }
+            });
+          }
+        });
+        this.kernelGateway.on('close',  (code) => {
+          console.log('kernelGateway.close ' + code);
+        });
+        this.kernelGateway.on('exit', (code) => {
+          console.log('kernelGateway.exit ' + code);
+        });
       }
     }
 

--- a/lib/notebook-editor.js
+++ b/lib/notebook-editor.js
@@ -8,14 +8,6 @@ import Immutable from 'immutable';
 import {CompositeDisposable} from 'atom';
 import {File} from 'pathwatcher';
 import {Emitter} from 'event-kit';
-import {Transformime} from 'transformime';
-import {
-  StreamTransformer,
-  TracebackTransformer,
-  MarkdownTransformer,
-  LaTeXTransformer,
-  PDFTransformer
-} from 'transformime-jupyter-transformers';
 import {
   listRunningKernels,
   connectToKernel,
@@ -41,12 +33,6 @@ export default class NotebookEditor {
       this.loadNotebookFile(uri);
       this.emitter = new Emitter();
       this.subscriptions = new CompositeDisposable();
-      this.transformer = new Transformime();
-      this.transformer.transformers.push(new StreamTransformer());
-      this.transformer.transformers.push(new TracebackTransformer());
-      this.transformer.transformers.push(new MarkdownTransformer());
-      this.transformer.transformers.push(new LaTeXTransformer());
-      this.transformer.transformers.push(new PDFTransformer());
       let language = this.state.getIn(['metadata', 'kernelspec', 'language']);
       execSync('lsof -t -i tcp:8888 | xargs kill');
       this.kernelGateway = spawn('jupyter', ['kernelgateway'], {
@@ -211,17 +197,14 @@ export default class NotebookEditor {
             [cellIndex, cell] = cellInfo;
           }
           console.log('output_received', payload.message.content);
-          let mimeBundle = this.makeMimeBundle(payload.message);
-          if (mimeBundle) {
-            this.transformer.transformRichest(mimeBundle, document).then(res => {
-              let {el} = res;
-              let outputs = this.state.getIn(['cells', cellIndex, 'outputs']);
-              outputs = outputs.push(el.outerHTML);
-              this.state = this.state.setIn(['cells', cellIndex, 'outputs'], outputs);
-              this._onChange();
-            }).catch(e => {
-              debugger;
-            });
+          let outputBundle = this.makeOutputBundle(payload.message);
+          if (outputBundle) {
+            let outputs = this.state.getIn(['cells', cellIndex, 'outputs']).push(outputBundle);
+            if (outputBundle.execution_count) {
+              outputs = outputs.set('execution_count', outputBundle.execution_count);
+            }
+            this.state = this.state.setIn(['cells', cellIndex, 'outputs'], outputs);
+            this._onChange();
           }
           break;
         case Dispatcher.actions.interrupt_kernel:
@@ -276,81 +259,49 @@ export default class NotebookEditor {
       return JSON.parse(fileString);
     }
 
-    //-------------------------------------------------------------------------
-    // Dirty dirty code for rendering messages
-    // Stolen from jupyter-display-area; all the good stuff is them,
-    // all the bugs are me.
-    //-------------------------------------------------------------------------
-
-    //TODO: make this less dirty
-    makeMimeBundle(msg) {
-      let json = {};
-      let msgType = json.output_type = msg.header.msg_type;
-      let content = msg.content;
-      switch (msgType) {
-        case 'clear_output':
-          // msg spec v4 had stdout, stderr, display keys
-          // v4.1 replaced these with just wait
-          // The default behavior is the same (stdout=stderr=display=True, wait=False),
-          // so v4 messages will still be properly handled,
-          // except for the rarely used clearing less than all output.
-          console.log('Not handling clear message!');
-          this.clear_output(msg.content.wait || false);
-          return;
-        case 'stream':
-          json.text = content.text;
-          json.name = content.name;
-          break;
-        case 'display_data':
-          json.data = content.data;
-          json.metadata = content.metadata;
-          break;
-        case 'execute_result':
-          json.data = content.data;
-          json.metadata = content.metadata;
-          json.execution_count = content.execution_count;
-          break;
-        case 'error':
-          json.ename = content.ename;
-          json.evalue = content.evalue;
-          json.traceback = content.traceback;
-          break;
-        case 'status':
-        case 'execute_input':
-          // Explicit ignore of status changes and input
-          return false;
-        default:
-          console.log('unhandled output message', msg);
-          return false;
       }
-      // this.append_output(json);
-      let bundle,
-          el;
-      bundle = {};
-      switch (json.output_type) {
-        case 'execute_result':
-        case 'display_data':
-          bundle = json.data;
-          break;
-        case 'stream':
-          bundle = {'text/plain': json.text};
-          // bundle = {
-          //   'jupyter/stream': json
-          // };
-          break;
-        case 'error':
-          bundle = {
-            'jupyter/traceback': json
-          };
-          break;
-        default:
-          console.warn('Unrecognized output type: ' + json.output_type);
-          bundle = {
-            'text/plain': 'Unrecognized output type' + JSON.stringify(json)
-          };
-      }
-      return bundle;
     }
+
+    makeOutputBundle(msg) {
+  		let json = {};
+  		json.output_type = msg.header.msg_type;
+  		switch (json.output_type) {
+  			case 'clear_output':
+  				// msg spec v4 had stdout, stderr, display keys
+  				// v4.1 replaced these with just wait
+  				// The default behavior is the same (stdout=stderr=display=True, wait=False),
+  				// so v4 messages will still be properly handled,
+  				// except for the rarely used clearing less than all output.
+  				console.log('Not handling clear message!');
+  				this.clear_output(msg.msg.content.wait || false);
+  				return;
+  			case 'stream':
+  				json.text = msg.content.text;
+  				json.name = msg.content.name;
+  				break;
+  			case 'display_data':
+  				json.data = msg.content.data;
+  				json.metadata = msg.content.metadata;
+  				break;
+  			case 'execute_result':
+  				json.data = msg.content.data;
+  				json.metadata = msg.content.metadata;
+  				json.execution_count = msg.content.execution_count;
+  				break;
+  			case 'error':
+  				json.ename = msg.content.ename;
+  				json.evalue = msg.content.evalue;
+  				json.traceback = msg.content.traceback;
+  				break;
+  			case 'status':
+  			case 'execute_input':
+  				return false;
+  			default:
+  				console.log('unhandled output message', msg);
+  				return false;
+  		}
+      return json;
+  	}
 
     save() {
       this.saveAs(this.getPath());

--- a/lib/notebook-editor.js
+++ b/lib/notebook-editor.js
@@ -247,7 +247,6 @@ export default class NotebookEditor {
       parsedFile.cells = parsedFile.cells.map(cell => {
         cell.metadata.id = uuid.v4();
         cell.metadata.focus = false;
-        cell.outputs = [];
         return cell;
       });
       if (parsedFile.cells.length > 0) parsedFile.cells[0].metadata.focus = true;

--- a/lib/notebook-editor.js
+++ b/lib/notebook-editor.js
@@ -86,15 +86,11 @@ export default class NotebookEditor {
     }
 
     findCellByID(id) {
-      return this.state.get('cells').findEntry(cell => {
-        return cell.get('id') == id;
-      });
+      return this.state.get('cells').findEntry(cell => cell.getIn(['metadata', 'id']) == id);
     }
 
     findActiveCell() {
-      let activeCellInfo = this.state.get('cells').findEntry(cell => cell.get('focus'));
-      // console.log('Active cell:', activeCellInfo);
-      return activeCellInfo;
+      return this.state.get('cells').findEntry(cell => cell.getIn(['metadata', 'focus']));
     }
 
     onAction = (payload) => {
@@ -137,7 +133,7 @@ export default class NotebookEditor {
             [activeCellIndex, activeCell] = activeCellInfo;
             // console.log(`Cell is at index ${cellIndex}`);
           }
-          this.state = this.state.setIn(['cells', activeCellIndex, 'focus'], false);
+          this.state = this.state.setIn(['cells', activeCellIndex, 'metadata', 'focus'], false);
           cellInfo = this.findCellByID(payload.cellID);
           if (!cellInfo || cellInfo === undefined || cellInfo === null) {
             // return console.log('Message is for another notebook');
@@ -145,7 +141,7 @@ export default class NotebookEditor {
           } else {
             [cellIndex, cell] = cellInfo;
           }
-          this.state = this.state.setIn(['cells', cellIndex, 'focus'], payload.isFocused);
+          this.state = this.state.setIn(['cells', cellIndex, 'metadata', 'focus'], payload.isFocused);
           this._onChange();
           break;
         case Dispatcher.actions.run_cell:
@@ -199,7 +195,7 @@ export default class NotebookEditor {
           future.onIOPub = (msg) => {
             Dispatcher.dispatch({
               actionType: Dispatcher.actions.output_received,
-              cellID: cell.get('id'),
+              cellID: cell.getIn(['metadata', 'id']),
               message: msg
             });
             clearTimeout(timer);
@@ -266,12 +262,12 @@ export default class NotebookEditor {
       this.file = new File(uri);
       let parsedFile = this.parseNotebookFile(this.file);
       parsedFile.cells = parsedFile.cells.map(cell => {
-        cell.id = uuid.v4();
+        cell.metadata.id = uuid.v4();
+        cell.metadata.focus = false;
         cell.outputs = [];
-        cell.focus = false;
         return cell;
       });
-      if (parsedFile.cells.length > 0) parsedFile.cells[0].focus = true;
+      if (parsedFile.cells.length > 0) parsedFile.cells[0].metadata.focus = true;
       this.state = Immutable.fromJS(parsedFile);
     }
 

--- a/lib/notebook-editor.js
+++ b/lib/notebook-editor.js
@@ -232,11 +232,25 @@ export default class NotebookEditor {
       // console.log('LOAD NOTEBOOK FILE');
       this.file = new File(uri);
       let parsedFile = this.parseNotebookFile(this.file);
-      parsedFile.cells = parsedFile.cells.map(cell => {
-        cell.metadata.id = uuid.v4();
-        cell.metadata.focus = false;
-        return cell;
-      });
+      if (parsedFile.cells) {
+        parsedFile.cells = parsedFile.cells.map(cell => {
+          cell.metadata.id = uuid.v4();
+          cell.metadata.focus = false;
+          return cell;
+        });
+      } else {
+        parsedFile.cells = [
+         {
+          cell_type: 'code',
+          execution_count: null,
+          metadata: {
+           collapsed: true
+          },
+          outputs: [],
+          source: []
+         }
+       ];
+      }
       if (parsedFile.cells.length > 0) parsedFile.cells[0].metadata.focus = true;
       this.state = Immutable.fromJS(parsedFile);
     }
@@ -421,7 +435,7 @@ export default class NotebookEditor {
 
     destroy() {
       console.log('destroy called');
-      this.subscriptions.dispose();
+      if (this.subscriptions) this.subscriptions.dispose();
       if (this.session) {
         this.session.shutdown().then(() => {
           this.kernelGateway.stdin.pause();

--- a/lib/notebook-editor.js
+++ b/lib/notebook-editor.js
@@ -140,6 +140,7 @@ export default class NotebookEditor {
               dismissable: true
             });
           }
+          if (cell.get('cell_type') !== 'code') return;
           this.state = this.state.setIn(['cells', cellIndex, 'outputs'], Immutable.List());
           var future = this.session.execute({code: cell.get('source')}, false);
           var timer;

--- a/lib/notebook-editor.js
+++ b/lib/notebook-editor.js
@@ -168,11 +168,29 @@ export default class NotebookEditor {
           console.log('output_received', payload.message.content);
           let outputBundle = this.makeOutputBundle(payload.message);
           if (outputBundle) {
-            let outputs = this.state.getIn(['cells', cellIndex, 'outputs']).push(outputBundle);
-            if (outputBundle.execution_count) {
-              outputs = outputs.set('execution_count', outputBundle.execution_count);
+            let outputs = this.state.getIn(['cells', cellIndex, 'outputs']).toJS();
+            let index = outputs.findIndex(output => output.output_type === outputBundle.output_type);
+            if (index > -1) {
+              if (outputBundle.data) {
+                outputs[index].data = outputs[index].data.concat(outputBundle.data);
+              }
+              if (outputBundle.text) {
+                if (outputs[index].name === outputBundle.name) {
+                  outputs[index].text = outputs[index].text.concat(outputBundle.text);
+                } else {
+                  outputs = outputs.concat(outputBundle);
+                }
+              }
+            } else {
+              outputs = outputs.concat(outputBundle);
             }
-            this.state = this.state.setIn(['cells', cellIndex, 'outputs'], outputs);
+            let execution_count = this.state.getIn(['cells', cellIndex, 'execution_count']);
+            if (outputBundle.execution_count) execution_count = outputBundle.execution_count;
+            let newCell = this.state.getIn(['cells', cellIndex]).merge({
+              execution_count,
+              outputs
+            });
+            this.state = this.state.setIn(['cells', cellIndex], newCell);
             this._onChange();
           }
           break;
@@ -280,18 +298,24 @@ export default class NotebookEditor {
   				// so v4 messages will still be properly handled,
   				// except for the rarely used clearing less than all output.
   				console.log('Not handling clear message!');
-  				this.clear_output(msg.msg.content.wait || false);
+  				this.clear_output(msg.content.wait || false);
   				return;
   			case 'stream':
-  				json.text = msg.content.text;
+  				json.text = msg.content.text.match(/[^\n]+(?:\r?\n|$)/g);
   				json.name = msg.content.name;
   				break;
   			case 'display_data':
-  				json.data = msg.content.data;
+  				json.data = Object.keys(msg.content.data).reduce((result, key) => {
+            result[key] = msg.content.data[key].match(/[^\n]+(?:\r?\n|$)/g);
+            return result;
+          }, {});
   				json.metadata = msg.content.metadata;
   				break;
   			case 'execute_result':
-  				json.data = msg.content.data;
+  				json.data = Object.keys(msg.content.data).reduce((result, key) => {
+            result[key] = msg.content.data[key].match(/[^\n]+(?:\r?\n|$)/g);
+            return result;
+          }, {});
   				json.metadata = msg.content.metadata;
   				json.execution_count = msg.content.execution_count;
   				break;

--- a/lib/text-editor.js
+++ b/lib/text-editor.js
@@ -46,7 +46,7 @@ export default class Editor extends React.Component {
   onTextChanged = () => {
     Dispatcher.dispatch({
       actionType: Dispatcher.actions.cell_source_changed,
-      cellID: this.props.data.get('id'),
+      cellID: this.props.data.getIn(['metadata', 'id']),
       source: this.textEditor.getText()
     });
   }

--- a/lib/text-editor.js
+++ b/lib/text-editor.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import {CompositeDisposable} from 'atom';
 import Dispatcher from './dispatcher';
 
@@ -12,7 +13,7 @@ export default class Editor extends React.Component {
   }
 
   componentDidMount() {
-    this.textEditorView = React.findDOMNode(this);
+    this.textEditorView = ReactDOM.findDOMNode(this);
     this.textEditor = this.textEditorView.getModel();
     let grammar = Editor.getGrammarForLanguage(this.props.language);
     this.textEditor.setGrammar(grammar);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react": "^0.14",
     "react-dom": "^0.14.3",
     "transformime": "^1",
-    "transformime-jupyter-transformers": ">=0.0.3",
+    "transformime-jupyter-transformers": "0.0.4",
     "uuid": "^2",
     "ws": "^0.8",
     "xmlhttprequest": "^1.8"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jupyter-js-services": ">=0.2.1",
     "pathwatcher": ">=4.4.3",
     "react": "^0.14",
+    "react-dom": "^0.14.3",
     "transformime": "^1",
     "transformime-jupyter-transformers": ">=0.0.3",
     "uuid": "^2",

--- a/styles/jupyter-notebook-atom.less
+++ b/styles/jupyter-notebook-atom.less
@@ -108,10 +108,9 @@
       overflow-wrap: break-word;
       font-size: @input-font-size;
       background-color: #fff;
-    }
-    // the output area in shadowDOM
-    .cell-output {
-
+      * {
+        font-family: monospace;
+      }
     }
   }
 }


### PR DESCRIPTION
* .ipynb files saved in Atom are now valid and can be opened with Jupyter Notebook, etc.
* Available cell outputs are displayed on load
* Cell outputs can be copied
* Jupyter Kernel Gateway will try alternate ports if 8888 is unavailable
* Fixes https://github.com/jupyter/atom-notebook/issues/13 and https://github.com/jupyter/atom-notebook/issues/12