### PR TITLE
Remove reliance on netstat / lsof to find an open port

### DIFF
--- a/lib/notebook-editor.js
+++ b/lib/notebook-editor.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import path from 'path';
+import portfinder from 'portfinder';
 import fs from 'fs-plus';
 import React from 'react';
 import uuid from 'uuid';
@@ -262,13 +263,9 @@ export default class NotebookEditor {
 
     launchKernelGateway() {
       let language = this.state.getIn(['metadata', 'kernelspec', 'language']);
-      let port = 8888;
-      try {
-        do {
-          execSync(`netstat -np TCP | grep "${port}"`);
-          port++;
-        } while (port < 9000);
-      } catch(error) {
+      portfinder.basePort = 8888;
+      portfinder.getPort(function(err, port){
+        if (err) throw err;
         this.kernelGateway = spawn('jupyter', ['kernelgateway', '--KernelGatewayApp.ip=localhost', `--KernelGatewayApp.port=${port}`], {
           cwd: atom.project.getPaths()[0]
         });
@@ -299,7 +296,7 @@ export default class NotebookEditor {
         this.kernelGateway.on('exit', (code) => {
           console.log('kernelGateway.exit ' + code);
         });
-      }
+      });
     }
 
     makeOutputBundle(msg) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "immutable": "^3",
     "jupyter-js-services": ">=0.2.1",
     "pathwatcher": ">=4.4.3",
+    "portfinder": "^0.4.0",
     "react": "^0.14",
     "react-dom": "^0.14.3",
     "transformime": "^1",


### PR DESCRIPTION
Instead of parsing system calls to find an open port, an alternative implementation could use something like the portfinder package to find an open port regardless of the platform we are running on.

I initially referenced this issue in #16 as a niggle over using `lsof`, which of course doesn't work on Windows. The workaround was to use `netstat` for a more platform-independent solution, however it still relies upon `grep` (which will fail on most Windows systems), and the whole situation feels hacky to me.

We can avoid the whole try {systemCall} catch {doWork} pattern if we use something like [portfinder](https://github.com/indexzero/node-portfinder/).

For a trivial example, see https://github.com/monkpit/atom-notebook/commit/db43af5da891045093b66cdd405a30dd8f240be5 . I'm sure the error handling could be made much more robust, I'm open to any suggestions :+1: :smile: 