### PR TITLE
Fix the deprecation warning in #47.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,9 +24,8 @@ export default {
     fixPath();
     this.openerDisposable = atom.workspace.addOpener(openURI);
     this.commands = atom.commands.add('.notebook-cell atom-text-editor', 'jupyter-notebook-atom:run', this.run);
-    atom.views.addViewProvider({
-      modelConstructor: NotebookEditor,
-      createView: model => {
+    atom.views.addViewProvider(NotebookEditor,
+      model => {
         let el = document.createElement('div');
         el.classList.add('notebook-wrapper');
         let viewComponent = ReactDOM.render(


### PR DESCRIPTION
This simple fix of removing the call for the object in the addViewProvider function fixes the deprecation warning listed in issue #47.